### PR TITLE
Relax Version Requirements for Rails 4 Upgrade

### DIFF
--- a/damage.gemspec
+++ b/damage.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "celluloid-io"
   spec.add_dependency "nokogiri"
   spec.add_dependency "thor"
-  spec.add_dependency "tzinfo",        "= 0.3.38"
+  spec.add_dependency "tzinfo",        ">= 0.3.38"
   spec.add_dependency "highline"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/damage.gemspec
+++ b/damage.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 3.2.16"
+  spec.add_dependency "activesupport", ">= 3.2.16"
   spec.add_dependency "celluloid"
   spec.add_dependency "celluloid-io"
   spec.add_dependency "nokogiri"

--- a/lib/damage/version.rb
+++ b/lib/damage/version.rb
@@ -1,3 +1,3 @@
 module Damage
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end


### PR DESCRIPTION
This branch has been sitting around for a while and is needed for whenever we upgrade to Rails 4.